### PR TITLE
nits: delete missing api links

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,10 +36,6 @@ API's are very simple and easy to understand.
 client.Board.Get("10")
 ```
 
-## Supported APIs
-
-See the [Supported APIs](docs/API.md) for supported APIs.
-
 ## Copyright and License
 
 Please see the LICENSE file for the included license information.


### PR DESCRIPTION
Thanks to go-miro, We were able to improve our business efficiency using Miro.

Since the link is gone and there doesn't seem to be a replacement, why not delete it?

Sincerely