### PR TITLE
Updated picture endpoint to use type correctly

### DIFF
--- a/miro/pictures_test.go
+++ b/miro/pictures_test.go
@@ -14,11 +14,12 @@ const (
 	testPictureImageURL = "test-image-url"
 )
 
-func getPictureJSON(id string) string {
+func getPictureJSON(pictureType string, id string) string {
 	return fmt.Sprintf(`{
+	"type": "%s",
 	"id": "%s",
 	"imageUrl": "%s"
-}`, id, testPictureImageURL)
+}`, pictureType, id, testPictureImageURL)
 }
 
 func getPicture(id string) *Picture {
@@ -33,19 +34,22 @@ func TestPicturesService_Get(t *testing.T) {
 	defer teardown()
 
 	tcs := map[string]struct {
+		pictureType string
 		id   string
 		want *Picture
 	}{
-		"ok": {"1", getPicture("1")},
+		"boards": {"boards", "1", getPicture("1")},
+		"teams": {"teams", "1", getPicture("1")},
+		"users": {"users", "1", getPicture("1")},
 	}
 
 	for n, tc := range tcs {
 		t.Run(n, func(t *testing.T) {
-			mux.HandleFunc(fmt.Sprintf("/type/%s/%s", tc.id, picturesPath), func(w http.ResponseWriter, r *http.Request) {
-				fmt.Fprint(w, fmt.Sprintf(getPictureJSON(tc.id)))
+			mux.HandleFunc(fmt.Sprintf("/%s/%s/%s", tc.pictureType, tc.id, picturesPath), func(w http.ResponseWriter, r *http.Request) {
+				fmt.Fprint(w, fmt.Sprintf(getPictureJSON(tc.pictureType, tc.id)))
 			})
 
-			got, err := client.Picture.Get(context.Background(), tc.id)
+			got, err := client.Picture.Get(context.Background(), pictureType(tc.pictureType), tc.id)
 			if err != nil {
 				t.Fatalf("Failed: %v", err)
 			}
@@ -62,20 +66,23 @@ func TestPicturesService_Upsert(t *testing.T) {
 	defer teardown()
 
 	tcs := map[string]struct {
+		pictureType string
 		id    string
 		Image *bytes.Buffer
 		want  *Picture
 	}{
-		"ok": {"1", bytes.NewBuffer(make([]byte, 0, 10)), getPicture("1")},
+		"boards": {"boards", "1", bytes.NewBuffer(make([]byte, 0, 10)), getPicture("1")},
+		"teams": {"teams", "1", bytes.NewBuffer(make([]byte, 0, 10)), getPicture("1")},
+		"users": {"users", "1", bytes.NewBuffer(make([]byte, 0, 10)), getPicture("1")},
 	}
 
 	for n, tc := range tcs {
 		t.Run(n, func(t *testing.T) {
-			mux.HandleFunc(fmt.Sprintf("/type/%s/%s", tc.id, picturesPath), func(w http.ResponseWriter, r *http.Request) {
-				fmt.Fprint(w, fmt.Sprintf(getPictureJSON(tc.id)))
+			mux.HandleFunc(fmt.Sprintf("/%s/%s/%s", tc.pictureType, tc.id, picturesPath), func(w http.ResponseWriter, r *http.Request) {
+				fmt.Fprint(w, fmt.Sprintf(getPictureJSON(tc.pictureType, tc.id)))
 			})
 
-			got, err := client.Picture.Upsert(context.Background(), tc.id, &UpsertPictureRequest{
+			got, err := client.Picture.Upsert(context.Background(), pictureType(tc.pictureType), tc.id, &UpsertPictureRequest{
 				tc.Image,
 			})
 			if err != nil {
@@ -94,20 +101,24 @@ func TestPicturesService_Delete(t *testing.T) {
 	defer teardown()
 
 	tcs := map[string]struct {
+		pictureType string
 		id   string
 		want *Picture
 	}{
-		"ok": {"1", getPicture("1")},
+		"boards": {"boards", "1", getPicture("1")},
+		"teams": {"teams", "1", getPicture("1")},
+		"users": {"users", "1", getPicture("1")},
 	}
+
 
 	for n, tc := range tcs {
 		t.Run(n, func(t *testing.T) {
-			mux.HandleFunc(fmt.Sprintf("/type/%s/%s", tc.id, picturesPath), func(w http.ResponseWriter, r *http.Request) {
+			mux.HandleFunc(fmt.Sprintf("/%s/%s/%s", tc.pictureType, tc.id, picturesPath), func(w http.ResponseWriter, r *http.Request) {
 				w.WriteHeader(http.StatusNoContent)
 				w.Write([]byte("{}"))
 			})
 
-			err := client.Picture.Delete(context.Background(), tc.id)
+			err := client.Picture.Delete(context.Background(), pictureType(tc.pictureType), tc.id)
 			if err != nil {
 				t.Fatalf("Failed: %v", err)
 			}


### PR DESCRIPTION
I have updated the API calls to the `v1/type/id/picture` as per the [miro documentation](https://developers.miro.com/reference#picture-object).

- The endpoint should end in `picture` (was `pictures`)
- `type` should be one of `boards`, `teams` or `users`
- Added happy tests only